### PR TITLE
:memo: Add method code mapping tables between slot index and FHED value

### DIFF
--- a/chunk_specifications/index.md
+++ b/chunk_specifications/index.md
@@ -104,17 +104,17 @@ Decoders should ignore them even if they contain a leading or trailing /.
 
 The `Compression method`, `Encryption method`, and `Cipher mode` fields in the FHED chunk must be set to the following PNA method codes (integer values):
 
-| Field               | Value | Algorithm/Mode        | Note                       |
-|:--------------------|------:|:----------------------|:---------------------------|
-| Compression method  | 0     | No compression        |                            |
-|                     | 1     | Deflate               | zlib compatible            |
-|                     | 2     | Zstandard             |                            |
-|                     | 4     | LZMA                  | xz                         |
-| Encryption method   | 0     | No encryption         |                            |
-|                     | 1     | AES (Rijndael)        | 256-bit key                |
-|                     | 2     | Camellia              | 256-bit key                |
-| Cipher mode         | 0     | CBC                   | Cipher Block Chaining      |
-|                     | 1     | CTR                   | Counter Mode               |
+| Field               | Value | Algorithm/Mode        | Note                       | Defined in                                                         |
+|:--------------------|------:|:----------------------|:---------------------------|:-------------------------------------------------------------------|
+| Compression method  | 0     | No compression        |                            |                                                                    |
+|                     | 1     | Deflate               | zlib compatible            | [§5.1](../compression_algorithms/index.md#51-deflate)              |
+|                     | 2     | Zstandard             |                            | [§5.2](../compression_algorithms/index.md#52-zstandard)            |
+|                     | 4     | LZMA                  | xz                         | [§5.3](../compression_algorithms/index.md#53-lzma)                 |
+| Encryption method   | 0     | No encryption         |                            |                                                                    |
+|                     | 1     | AES (Rijndael)        | 256-bit key                | [§6.1](../cipher_algorithms/index.md#61-rijndael)                  |
+|                     | 2     | Camellia              | 256-bit key                | [§6.2](../cipher_algorithms/index.md#62-camellia)                  |
+| Cipher mode         | 0     | CBC                   | Cipher Block Chaining      | [§7.1](../cipher_modes/index.md#71-cipher-block-chaining-mode-cbc) |
+|                     | 1     | CTR                   | Counter Mode               | [§7.2](../cipher_modes/index.md#72-counter-mode-ctr)               |
 
 **Note:**
 - Do not use algorithm-internal method codes (such as zlib's method/flags code) in these fields. Only the PNA method code (integer value) must be stored in the FHED chunk fields.

--- a/cipher_algorithms/index.md
+++ b/cipher_algorithms/index.md
@@ -2,6 +2,18 @@
 
 PNA employs multiple cipher algorithms. This specification is designed to ensure the secure use of PNA by enabling the selection of alternative cipher algorithms in the event of a critical flaw discovered in a specific algorithm. In this chapter, we will define the cipher algorithms available for use in PNA. For information on cipher mode, please refer to the following chapter.
 
+### Method code mapping
+
+In this chapter, "PNA cipher method N" refers to the **slot index** in the registry below. Encoders MUST write the corresponding **FHED value**, not the slot index, into the `Encryption method` field of the FHED chunk.
+
+| Slot (used in this chapter) | FHED `Encryption method` value | Algorithm      | Section              |
+|----------------------------:|:------------------------------:|:---------------|:---------------------|
+| —                           | 0                              | No encryption  | —                    |
+| 0                           | 1                              | Rijndael (AES) | [§6.1](#61-rijndael) |
+| 1                           | 2                              | Camellia       | [§6.2](#62-camellia) |
+
+See also [§4.1.4](../chunk_specifications/index.md#414-fhed-file-header) for the full list of FHED field values.
+
 ### 6.1 Rijndael
 
 PNA cipher method 0 specifies Rijndael encryption with a key length of 256 bits and a block length of 128 bits. Rijndael, generally known as AES(Advanced Encryption Standard), is a widely accepted symmetric encryption algorithm renowned for its security and efficiency. It operates on blocks of data and supports key sizes of 128, 192, and 256 bits. In PNA, Rijndael with a key length of 256 bits is utilized. This provides a high level of encryption strength, ensuring that the archived data remains secure against unauthorized access.

--- a/compression_algorithms/index.md
+++ b/compression_algorithms/index.md
@@ -2,6 +2,19 @@
 
 PNA allows the use of multiple compression algorithms. This is designed to achieve high performance by switching compression algorithms depending on the intended use and environment.
 
+### Method code mapping
+
+In this chapter, "PNA compression method N" refers to the **slot index** in the registry below. Encoders MUST write the corresponding **FHED value**, not the slot index, into the `Compression method` field of the FHED chunk.
+
+| Slot (used in this chapter) | FHED `Compression method` value | Algorithm      | Section               |
+|----------------------------:|:-------------------------------:|:---------------|:----------------------|
+| —                           | 0                               | No compression | —                     |
+| 0                           | 1                               | Deflate        | [§5.1](#51-deflate)   |
+| 1                           | 2                               | ZStandard      | [§5.2](#52-zstandard) |
+| 2                           | 4                               | LZMA           | [§5.3](#53-lzma)      |
+
+See also [§4.1.4](../chunk_specifications/index.md#414-fhed-file-header) for the full list of FHED field values.
+
 ### 5.1. Deflate
 
 PNA compression method 0 specifies deflate/inflate compression with a sliding window of at most 32768 bytes. Deflate compression is an LZ77 derivative used in zip, gzip, pkzip, and related programs. Extensive research has been done supporting its patent-free status. Portable C implementations are freely available.


### PR DESCRIPTION
§5 (Compression) and §6 (Cipher algorithms) use slot-index numbering (e.g. "PNA compression method 2" = LZMA) while §4.1.4 FHED field values use a different binary value space (LZMA = 4). The two number systems were not cross-referenced, leaving readers uncertain which "method N" was meant.

- Add a "Method code mapping" section at the top of §5 and §6 showing the slot-index <-> FHED value correspondence with links to each algorithm subsection.
- Add a "Defined in" column to the §4.1.4 FHED field values table linking to the algorithm/mode sections.