### PR TITLE
:memo: Add fSIZ Raw file size hint chunk specification

### DIFF
--- a/chunk_specifications/index.md
+++ b/chunk_specifications/index.md
@@ -335,6 +335,24 @@ When `FHED.Entry kind` is `3` (hard link) and the link target type is `2` (direc
 
 On systems that cannot create hard links to directories (e.g., POSIX-compliant file systems that prohibit hardlink-to-directory), implementations MAY fall back to creating a symbolic link to the target directory when extracting such entries. This fallback is a local substitution at extraction time and does not modify the on-wire `FHED.Entry kind` or `fLTP` values.
 
+#### 4.2.5 Raw file size hint
+
+##### 4.2.5.1 fSIZ Raw file size hint
+
+A hint of the byte count of the source file, prior to any compression or encryption, is recorded.
+This chunk appeared after `FHED` chunk and before `FEND` chunk.
+
+| significance |  size   | description                 |
+|:-------------|:-------:|:----------------------------|
+| size         | n-byte  | Big-endian unsigned integer |
+
+The chunk data consists of zero or more bytes representing the size as a big-endian unsigned integer. Decoders MUST interpret a zero-length chunk data as a size of zero.
+
+##### Constraints
+
+- Encoders MAY write `fSIZ` for any entry kind; for entries whose `FHED.Entry kind` is not `0` (regular file), the value has no defined semantics and decoders MUST ignore it.
+- `fSIZ` is informational. The value is a hint only. Decoders MUST NOT rely on it for buffer allocation, memory reservation, or security decisions, and MUST NOT require the reported size to match the actual size of the decompressed and decrypted entry data.
+
 ### 4.3. Summary of standard chunks
 
 This table summarizes some properties of the standard chunk types.
@@ -367,6 +385,7 @@ Ancillary chunks
 | fPRM  |        Yes          |        No         |   Yes    | Between `FHED` and `FEND`                    |
 | xATR  |        Yes          |       Yes         |   Yes    | Between `FHED` and `FEND`                    |
 | fLTP  |        Yes          |        No         |   Yes    | Between `FHED` and `FEND`                    |
+| fSIZ  |        Yes          |        No         |   Yes    | Between `FHED` and `FEND`                    |
 
 ### 4.4. Additional chunk types
 

--- a/index.md
+++ b/index.md
@@ -54,6 +54,8 @@ PNA is robust, providing both full file integrity checking and simple detection 
       - [4.2.3.1 xATR Extended attribute](./chunk_specifications/index.md#4231-xatr-extended-attribute)
     - [4.2.4 Link target type](./chunk_specifications/index.md#424-link-target-type)
       - [4.2.4.1 fLTP Link target type](./chunk_specifications/index.md#4241-fltp-link-target-type)
+    - [4.2.5 Raw file size hint](./chunk_specifications/index.md#425-raw-file-size-hint)
+      - [4.2.5.1 fSIZ Raw file size hint](./chunk_specifications/index.md#4251-fsiz-raw-file-size-hint)
   - [4.3. Summary of standard chunks](./chunk_specifications/index.md#43-summary-of-standard-chunks)
   - [4.4. Additional chunk types](./chunk_specifications/index.md#44-additional-chunk-types)
 - [5. Compression algorithms](./compression_algorithms/index.md)


### PR DESCRIPTION
fSIZ has been implemented in libpna since "Add support fSIZ chunk" but was never documented in the formal specification. This left the on-wire encoding and the intended semantics (a size hint, not an authoritative value) undefined for other implementations.

- Add §4.2.5 Raw file size hint describing the fSIZ chunk as an ancillary, unsafe-to-copy chunk storing a variable-length big-endian unsigned integer.
- Specify that a zero-length chunk data represents a size of zero. Encoders MAY choose any byte width; no stripping of leading zero bytes is required.
- Clarify that the value is informational only. Decoders MUST NOT rely on it for buffer allocation, memory reservation, or security decisions.
- Clarify that the value has defined semantics only for regular file entries; decoders MUST ignore fSIZ on other entry kinds.
- Add fSIZ row to the §4.3 Ancillary chunks summary table.
- Register §4.2.5 and §4.2.5.1 in the root index.md Table of Contents.