### PR TITLE
:pencil2: Fix incorrect chunk name SHAD to SHED

### DIFF
--- a/cipher_algorithms/index.md
+++ b/cipher_algorithms/index.md
@@ -28,7 +28,7 @@ It is important to emphasize that the boundaries between FDAT chunks are arbitra
 
 In the same vein, there is no required correlation between the structure of the file data and deflate block boundaries or FDAT chunk boundaries. The complete entry data is represented by a single Rijndael-encrypted datastream that is stored in some number of FDAT chunks; a decoder that assumes any more than this is incorrect. (Of course, some encoder implementations may emit files in which some of these structures are indeed related. But decoders cannot rely on this.)
 
-Treat all SDAT chunks between SHAD and SEND in the same way.
+Treat all SDAT chunks between SHED and SEND in the same way.
 
 Additional documentation is available from the Cryptographic Standards and Guidelines archives at [http://www.nist.gov/aes](http://www.nist.gov/aes) and the FIPS Publication 197 [FIPS-197](https://csrc.nist.gov/publications/detail/fips/197/final).
 
@@ -46,6 +46,6 @@ It is important to emphasize that the boundaries between FDAT chunks are arbitra
 
 In the same vein, there is no required correlation between the structure of the file data and deflate block boundaries or FDAT chunk boundaries. The complete entry data is represented by a single Camellia-encrypted datastream that is stored in some number of FDAT chunks; a decoder that assumes any more than this is incorrect. (Of course, some encoder implementations may emit files in which some of these structures are indeed related. But decoders cannot rely on this.)
 
-Treat all SDAT chunks between SHAD and SEND in the same way.
+Treat all SDAT chunks between SHED and SEND in the same way.
 
 Additional documentation is available from the Camellia Specification at [RFC-3713](https://datatracker.ietf.org/doc/html/rfc3713).

--- a/compression_algorithms/index.md
+++ b/compression_algorithms/index.md
@@ -41,7 +41,7 @@ It is important to emphasize that the boundaries between FDAT chunks are arbitra
 
 In the same vein, there is no required correlation between the structure of the file data and deflate block boundaries or FDAT chunk boundaries. The complete entry data is represented by a single zlib datastream that is stored in some number of FDAT chunks; a decoder that assumes any more than this is incorrect. (Of course, some encoder implementations may emit files in which some of these structures are indeed related. But decoders cannot rely on this.)
 
-Treat all SDAT chunks between SHAD and SEND in the same way.
+Treat all SDAT chunks between SHED and SEND in the same way.
 
 Additional documentation and portable C code for deflate and inflate are available from the Info-ZIP archives at [ftp://ftp.info-zip.org/pub/infozip/](ftp://ftp.info-zip.org/pub/infozip/).
 
@@ -57,7 +57,7 @@ It is important to emphasize that the boundaries between FDAT chunks are arbitra
 
 In the same vein, there is no required correlation between the structure of the file data or FDAT chunk boundaries. The complete entry data is represented by a single ZStandard datastream that is stored in some number of FDAT chunks; a decoder that assumes any more than this is incorrect. (Of course, some encoder implementations may emit files in which some of these structures are indeed related. But decoders cannot rely on this.)
 
-Treat all SDAT chunks between SHAD and SEND in the same way.
+Treat all SDAT chunks between SHED and SEND in the same way.
 
 Additional documentation and Reference implementations of ZStandard are available from GitHub at [https://facebook.github.io/zstd/](https://facebook.github.io/zstd/) and [https://github.com/facebook/zstd](https://github.com/facebook/zstd)
 
@@ -76,6 +76,6 @@ It is important to emphasize that the boundaries between FDAT chunks are arbitra
 
 In the same vein, there is no required correlation between the structure of the file data or FDAT chunk boundaries. The complete entry data is represented by a single LZMA datastream that is stored in some number of FDAT chunks; a decoder that assumes any more than this is incorrect. (Of course, some encoder implementations may emit files in which some of these structures are indeed related. But decoders cannot rely on this.)
 
-Treat all SDAT chunks between SHAD and SEND in the same way.
+Treat all SDAT chunks between SHED and SEND in the same way.
 
 Additional documentation and Reference implementations of LZMA are available from GitHub at [https://github.com/tukaani-project/xz](https://github.com/tukaani-project/xz).


### PR DESCRIPTION
The Solid mode header chunk is defined as `SHED` in chunk_specifications/index.md (§4.1.8), but the cipher and compression algorithm sections referred to it as `SHAD` in five places. Correct all occurrences so the spec is internally consistent and implementers are not misled.