### PR TITLE
:memo: Add missing FIPS-197 and RFC-3713 reference entries

### DIFF
--- a/references/index.md
+++ b/references/index.md
@@ -51,3 +51,11 @@ Alex Biryukov, Daniel Dinu, and Dmitry Khovratovich University of Luxembourg, Lu
 ## **[RFC-9106]**
 A. Biryukov University of Luxembourg, D. Dinu University of Luxembourg, D. Khovratovich ABDK Consulting, S. Josefsson SJD AB, Argon2 Memory-Hard Function for Password Hashing and Proof-of-Work Applications, September 2021.
 [https://tools.ietf.org/html/rfc9106](https://tools.ietf.org/html/rfc9106)
+
+### **[RFC-3713]**
+M. Matsui, J. Nakajima, and S. Moriai, "A Description of the Camellia Encryption Algorithm", RFC 3713, Mitsubishi Electric Corporation / NTT, April 2004.
+[https://datatracker.ietf.org/doc/html/rfc3713](https://datatracker.ietf.org/doc/html/rfc3713)
+
+### **[FIPS-197]**
+National Institute of Standards and Technology, "Advanced Encryption Standard (AES)", Federal Information Processing Standards Publication 197, November 2001 (updated 2023).
+[https://csrc.nist.gov/publications/detail/fips/197/final](https://csrc.nist.gov/publications/detail/fips/197/final)


### PR DESCRIPTION
## Summary
- `cipher_algorithms/index.md` (§6.1, §6.2) already links to FIPS-197 and RFC-3713, but `references/index.md` had no corresponding entries.
- Adds the two missing reference entries.

## Context
Split out of #45 as an independent, GCM-unrelated fix so it can be reviewed and merged separately. #45 will be rebased on top of this branch once it merges.